### PR TITLE
script enhancement for bulk double sided sanning

### DIFF
--- a/merge-two-siders.sh
+++ b/merge-two-siders.sh
@@ -9,28 +9,27 @@
 
 set -eu
 
-DIR=/sharedfolders/Daten/Paperless/consume/
-SUB_DIR=two-siders/
+DIR=/docker-compose/sandbox/paperless-ng/volumes/consume/
+SUB_DIR=recto-verso/
 
 cd ${DIR}
 
 mergePdf() {
     FILES="$(find $SUB_DIR -name '*pdf' | sort -n | head -2)"
     FILE_COUNT=$(echo "$FILES" | wc -l)
-
     if (( ${FILE_COUNT} < 2 )); then
         echo "Not enough pdfs. Two needed, exiting."
         exit 1
     fi
 
-    FIRST_FILE=$(echo "$FILES" | head -1)
-    SECOND_FILE=$(echo "$FILES" | tail -1)
+    FIRST_FILE=$(echo "$FILES" |sed -n '1p')
+    SECOND_FILE=$(echo "$FILES" |sed -n '2p')
     OUTPUT_FILE="$(basename $FIRST_FILE .pdf)-merged.pdf"
 
     echo "Merging PDFs ${FILES} to ${OUTPUT_FILE}"
 
-    docker run --rm -v $DIR:/app -w /app minidocks/ghostscript -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile=${OUTPUT_FILE} ${FILES}
-
+    docker run --rm -v $DIR:/app -w /app pdftk/pdftk A="${FIRST_FILE}" B="${SECOND_FILE}" shuffle A Bend-1 output $OUTPUT_FILE
+    
     RC=$?
 
     if (( $RC != 0 )); then


### PR DESCRIPTION
1. first you scan all the odd pages in a file, then you scan all the even pages in a second file. the merge will reorder the pages in the correct order.

2. If you have 3 or more files, the "SECOND FILE" variable is set with the last file in the folder. to avoid this i updated the assignement like this FIRST_FILE=$(echo "$FILES" |sed -n '1p') SECOND_FILE=$(echo "$FILES" |sed -n '2p')